### PR TITLE
Add TFI as a combined-method pipeline

### DIFF
--- a/index.html
+++ b/index.html
@@ -530,6 +530,7 @@
                 <option value="none" selected>Standard</option>
                 <option value="tgv">TGV</option>
                 <option value="qsmart">QSMART</option>
+                <option value="tfi">TFI</option>
               </select>
             </div>
             <div class="param-group" id="sidebarUnwrapGroup">
@@ -826,7 +827,27 @@
               <option value="none" selected>Standard Pipeline</option>
               <option value="tgv">TGV (Total Generalized Variation)</option>
               <option value="qsmart">QSMART (QSM Artifact Reduction Technique)</option>
+              <option value="tfi">TFI (Total Field Inversion)</option>
             </select>
+          </div>
+
+          <!-- TFI Settings -->
+          <div id="tfi_settings" class="method-settings" style="display: none;">
+            <div class="method-links">
+              <a href="https://doi.org/10.1002/mrm.26946" target="_blank" rel="noopener" title="DOI: 10.1002/mrm.26946"><svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/></svg>Paper</a>
+              <a href="https://github.com/astewartau/QSM.rs" target="_blank" rel="noopener" title="Code: QSM.rs"><svg viewBox="0 0 16 16" width="14" height="14" fill="currentColor"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/></svg>Code</a>
+            </div>
+            <p style="font-size: 0.75rem; line-height: 1.4; color: var(--color-text); background: rgba(230,160,30,0.10); border-left: 3px solid #e6a01e; padding: var(--space-xs) var(--space-sm); margin: 0 0 var(--space-sm); border-radius: 3px;">
+              TFI is single-step: it inverts the <strong>total field</strong> directly (its own background removal). Larger <strong>preconditioner</strong> suits data with strong background fields (e.g. air near sinuses).
+            </p>
+            <div class="param-group">
+              <label class="param-label" for="tfiLambda">Regularization (lambda)</label>
+              <input type="number" id="tfiLambda" value="0.000075" min="0" max="0.01" step="0.000025">
+            </div>
+            <div class="param-group">
+              <label class="param-label" for="tfiPrecond">Preconditioner</label>
+              <input type="number" id="tfiPrecond" value="30" min="1" max="300" step="1">
+            </div>
           </div>
 
           <!-- TGV Settings -->

--- a/js/app/config.js
+++ b/js/app/config.js
@@ -17,7 +17,7 @@ const isModule = typeof exports !== 'undefined' || (typeof window !== 'undefined
 export const VERSION = '0.0.0';
 
 // QSM.rs core library version (the pinned qsm-core dependency tag in rust-wasm/Cargo.toml)
-export const QSM_RS_VERSION = '0.18.0';
+export const QSM_RS_VERSION = '0.23.0';
 
 // Physics constants
 export const PHYSICS = {
@@ -77,6 +77,7 @@ import {
   WHQSM_DEFAULTS as _WHQSM,
   HDQSM_DEFAULTS as _HDQSM,
   MEDI_DEFAULTS as _MEDI,
+  TFI_DEFAULTS as _TFI,
   QSMART_DEFAULTS as _QSMART,
   ROMEO_DEFAULTS as _ROMEO,
   MCPC3DS_DEFAULTS as _MCPC3DS,
@@ -316,6 +317,19 @@ export const MEDI_DEFAULTS = {
   data_weighting: _MEDI.data_weighting,
 };
 
+// TFI (preconditioned total field inversion) — single-step combined method (like TGV/QSMART).
+export const TFI_DEFAULTS = {
+  lambda: _TFI.lambda,
+  precond: _TFI.precond,
+  merit: _TFI.merit,
+  data_weighting: _TFI.data_weighting,
+  percentage: _TFI.percentage,
+  cg_tol: _TFI.cg_tol,
+  cg_max_iter: _TFI.cg_max_iter,
+  max_iter: _TFI.max_iter,
+  tol: _TFI.tol,
+};
+
 // Example data (downloaded from OSF during CI, served same-origin)
 export const EXAMPLE_DATA = {
   baseUrl: './data/example',
@@ -366,7 +380,7 @@ export const STAGE_DISPLAY_NAMES = {
 
 // Pipeline method options
 export const PIPELINE_METHODS = {
-  combined: ['none', 'tgv', 'qsmart'],
+  combined: ['none', 'tgv', 'qsmart', 'tfi'],
   unwrap: ['romeo', 'laplacian'],
   phaseOffset: ['mcpc3ds', 'none'],
   fieldCalculation: ['weighted_avg', 'linear_fit'],
@@ -383,6 +397,7 @@ export const PIPELINE_DEFAULTS = {
   swi: { ...SWI_DEFAULTS },
   tgv: { ...TGV_DEFAULTS },
   qsmart: { ...QSMART_DEFAULTS },
+  tfi: { ...TFI_DEFAULTS },
   unwrapping_algorithm: 'romeo',
   phase_offset_method: 'mcpc3ds',
   b0_estimation: 'weighted_avg',
@@ -479,6 +494,7 @@ const QSMConfig = {
   SWI_DEFAULTS,
   TGV_DEFAULTS,
   QSMART_DEFAULTS,
+  TFI_DEFAULTS,
   ROMEO_DEFAULTS,
   MCPC3DS_DEFAULTS,
   LINEAR_FIT_DEFAULTS,

--- a/js/app/qsm-defaults.js
+++ b/js/app/qsm-defaults.js
@@ -168,6 +168,18 @@ export const MEDI_DEFAULTS = {
   "tol": 0.1
 };
 
+export const TFI_DEFAULTS = {
+  "lambda": 0.000075,
+  "precond": 30,
+  "merit": false,
+  "data_weighting": 1,
+  "percentage": 0.9,
+  "cg_tol": 0.01,
+  "cg_max_iter": 100,
+  "max_iter": 10,
+  "tol": 0.1
+};
+
 export const QSMART_DEFAULTS = {
   "ilsqr_tol": 0.01,
   "ilsqr_max_iter": 50,

--- a/js/controllers/PipelineSettingsController.js
+++ b/js/controllers/PipelineSettingsController.js
@@ -12,7 +12,7 @@ import {
   VSHARP_DEFAULTS, SHARP_DEFAULTS, RESHARP_DEFAULTS, HARPERELLA_DEFAULTS,
   ISMV_DEFAULTS, PDF_DEFAULTS, LBV_DEFAULTS,
   TKD_DEFAULTS, TSVD_DEFAULTS, TIKHONOV_DEFAULTS,
-  TV_DEFAULTS, RTS_DEFAULTS, NLTV_DEFAULTS, MEDI_DEFAULTS,
+  TV_DEFAULTS, RTS_DEFAULTS, NLTV_DEFAULTS, MEDI_DEFAULTS, TFI_DEFAULTS,
   NDI_DEFAULTS, FANSI_DEFAULTS, L1QSM_DEFAULTS, WHQSM_DEFAULTS, HDQSM_DEFAULTS,
 } from '../app/config.js';
 
@@ -67,6 +67,10 @@ export class PipelineSettingsController {
     this._setEl('tgvRegularization', 2); // UI preset level (qsmbly-specific)
     this._setEl('tgvIterations', TGV_DEFAULTS.iterations);
     this._setEl('tgvErosions', TGV_DEFAULTS.erosions);
+
+    // TFI defaults
+    this._setEl('tfiLambda', TFI_DEFAULTS.lambda);
+    this._setEl('tfiPrecond', TFI_DEFAULTS.precond);
 
     // SWI defaults
     this._setEl('swiScaling', SWI_DEFAULTS.scaling);
@@ -319,6 +323,11 @@ export class PipelineSettingsController {
         iterations: parseInt(this._getEl('tgvIterations')),
         erosions: parseInt(this._getEl('tgvErosions'))
       },
+      tfi: {
+        ...TFI_DEFAULTS,
+        lambda: parseFloat(this._getEl('tfiLambda')),
+        precond: parseFloat(this._getEl('tfiPrecond'))
+      },
       qsmart: {
         sdf_sigma1_stage1: parseFloat(this._getEl('qsmartSdfSigma1Stage1')),
         sdf_sigma2_stage1: parseFloat(this._getEl('qsmartSdfSigma2Stage1')),
@@ -540,7 +549,8 @@ export class PipelineSettingsController {
     const phase_offset_method = this._getEl('phase_offset_method') || 'mcpc3ds';
     const isTgv = combined_method === 'tgv';
     const isQsmart = combined_method === 'qsmart';
-    const isCombined = isTgv || isQsmart;
+    const isTfi = combined_method === 'tfi';
+    const isCombined = isTgv || isQsmart || isTfi;
     const isMcpc3ds = phase_offset_method === 'mcpc3ds';
     const isMultiEcho = nEchoes > 1;
 
@@ -554,6 +564,9 @@ export class PipelineSettingsController {
     // QSMART settings - show when QSMART selected in any mode
     this._showEl('qsmart_settings', isQsmart);
     if (isQsmart) this._updateQsmartInnerVisibility();
+
+    // TFI settings - show when TFI selected in any mode
+    this._showEl('tfi_settings', isTfi);
 
     // Phase unwrapping (check this first — Laplacian disables offset removal + bipolar)
     const currentUnwrapMethod = this._getEl('unwrapping_algorithm') || 'romeo';

--- a/js/modules/ConfigBridge.js
+++ b/js/modules/ConfigBridge.js
@@ -18,6 +18,7 @@ export function buildConfig(settings, options = {}) {
 
   const isTgv = settings.combined_method === 'tgv';
   const isQsmart = settings.combined_method === 'qsmart';
+  const isTfi = settings.combined_method === 'tfi';
 
   const config = {
     pipeline: {
@@ -50,6 +51,7 @@ export function buildConfig(settings, options = {}) {
 
   if (isTgv) config.inversion.algorithm = 'tgv';
   else if (isQsmart) config.inversion.algorithm = 'qsmart';
+  else if (isTfi) config.inversion.algorithm = 'tfi';
   else {
     // Translate qsmbly dropdown value -> qsmxt-config serde string.
     // 'fansitgv' maps to 'fansi-tgv'; all others pass through unchanged.
@@ -71,6 +73,12 @@ export function buildConfig(settings, options = {}) {
   if (settings.whqsm) config.inversion.whqsm = settings.whqsm;
   if (settings.hdqsm) config.inversion.hdqsm = settings.hdqsm;
   if (settings.medi) config.inversion.medi = settings.medi;
+  if (settings.tfi) config.inversion.tfi = {
+    lambda: settings.tfi.lambda, precond: settings.tfi.precond, merit: settings.tfi.merit,
+    data_weighting: settings.tfi.data_weighting, percentage: settings.tfi.percentage,
+    cg_tol: settings.tfi.cg_tol, cg_max_iter: settings.tfi.cg_max_iter,
+    max_iter: settings.tfi.max_iter, tol: settings.tfi.tol,
+  };
   if (settings.ilsqr) config.inversion.ilsqr = settings.ilsqr;
   if (settings.tgv) config.inversion.tgv = {
     iterations: settings.tgv.iterations, erosions: settings.tgv.erosions,

--- a/rust-wasm/Cargo.lock
+++ b/rust-wasm/Cargo.lock
@@ -377,7 +377,7 @@ dependencies = [
 [[package]]
 name = "qsm-core"
 version = "0.0.0"
-source = "git+https://github.com/astewartau/QSM.rs.git?tag=v0.21.0#6f5c957894fe576dc931bd30e441172e25a0101a"
+source = "git+https://github.com/astewartau/QSM.rs.git?tag=v0.23.0#baca0242a025a8ed1f5b45a8157b2123ce67372c"
 dependencies = [
  "bytemuck",
  "delaunator",
@@ -406,7 +406,7 @@ dependencies = [
 [[package]]
 name = "qsmxt-config"
 version = "0.0.0"
-source = "git+https://github.com/QSMxT/QSMxT.git?tag=v9.9.0#de16086da0f07bf7b91018b69486ce72c573e31a"
+source = "git+https://github.com/QSMxT/QSMxT.git?tag=v9.11.0#d75a93421451f6de77a13e1be97eb15f24e36a8a"
 dependencies = [
  "qsm-core",
  "serde",

--- a/rust-wasm/Cargo.toml
+++ b/rust-wasm/Cargo.toml
@@ -14,12 +14,12 @@ simd = ["qsm-core/simd"]
 
 [dependencies]
 # Core QSM algorithms. No `parallel` feature — WASM is single-threaded.
-qsm-core = { git = "https://github.com/astewartau/QSM.rs.git", tag = "v0.21.0" }
+qsm-core = { git = "https://github.com/astewartau/QSM.rs.git", tag = "v0.23.0" }
 
 # Pipeline configuration, command generation, methods text.
 # qsmxt-config's canonical home is the QSMxT/QSMxT workspace (the old
 # astewartau/qsmxt.rs repo is being retired).
-qsmxt-config = { git = "https://github.com/QSMxT/QSMxT.git", tag = "v9.9.0" }
+qsmxt-config = { git = "https://github.com/QSMxT/QSMxT.git", tag = "v9.11.0" }
 
 # WASM bindings
 wasm-bindgen = "0.2"

--- a/rust-wasm/src/lib.rs
+++ b/rust-wasm/src/lib.rs
@@ -2939,6 +2939,7 @@ config_defaults!(get_l1qsm_defaults, qsmxt_config::config::L1qsmConfig);
 config_defaults!(get_whqsm_defaults, qsmxt_config::config::WhqsmConfig);
 config_defaults!(get_hdqsm_defaults, qsmxt_config::config::HdqsmConfig);
 config_defaults!(get_medi_defaults, qsmxt_config::config::MediConfig);
+config_defaults!(get_tfi_defaults, qsmxt_config::config::TfiConfig);
 config_defaults!(get_qsmart_defaults, qsmxt_config::config::QsmartConfig);
 config_defaults!(get_romeo_defaults, qsmxt_config::config::RomeoConfig);
 config_defaults!(get_mcpc3ds_defaults, qsmxt_config::config::Mcpc3dsConfig);

--- a/scripts/generate-defaults.mjs
+++ b/scripts/generate-defaults.mjs
@@ -46,6 +46,7 @@ const defaults = {
   WHQSM_DEFAULTS: JSON.parse(wasmModule.get_whqsm_defaults()),
   HDQSM_DEFAULTS: JSON.parse(wasmModule.get_hdqsm_defaults()),
   MEDI_DEFAULTS: JSON.parse(wasmModule.get_medi_defaults()),
+  TFI_DEFAULTS: JSON.parse(wasmModule.get_tfi_defaults()),
   QSMART_DEFAULTS: JSON.parse(wasmModule.get_qsmart_defaults()),
   ROMEO_DEFAULTS: JSON.parse(wasmModule.get_romeo_defaults()),
   MCPC3DS_DEFAULTS: JSON.parse(wasmModule.get_mcpc3ds_defaults()),


### PR DESCRIPTION
Adds **TFI** (preconditioned Total Field Inversion; Liu et al., MRM 2017) alongside TGV and QSMART as a single-step combined method (background removal + dipole inversion, from the total field).

## Changes
- **rust-wasm**: bump `qsm-core` v0.21.0→**v0.23.0** and `qsmxt-config` v9.9.0→**v9.11.0**; add `get_tfi_defaults()` (config_defaults! over `TfiConfig`).
- **defaults**: `generate-defaults.mjs` + `js/app/qsm-defaults.js` now emit `TFI_DEFAULTS` (lambda 7.5e-5, precond 30, …).
- **config.js**: `TFI_DEFAULTS` export; `'tfi'` in `PIPELINE_METHODS.combined` + `PIPELINE_DEFAULTS`; `QSM_RS_VERSION` 0.18.0→0.23.0.
- **index.html**: TFI in both combined-method selects + a TFI settings panel (regularization λ + preconditioner).
- **ConfigBridge.js** + **PipelineSettingsController.js**: `isTfi` → `inversion.algorithm='tfi'` + params; show/hide, defaults, and save() wiring.

WASM rebuilt; `TFI_DEFAULTS` confirmed generated. All changed JS passes `node --check` (repo's jest suites are pre-broken on main, unrelated). Tested locally in-browser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)