### PR TITLE
chore: bump qsm-core to v0.30.0 and qsmxt-config to v9.17.0

### DIFF
--- a/rust-wasm/Cargo.lock
+++ b/rust-wasm/Cargo.lock
@@ -856,7 +856,7 @@ dependencies = [
 [[package]]
 name = "qsm-core"
 version = "0.0.0"
-source = "git+https://github.com/astewartau/QSM.rs.git?tag=v0.28.0#ff0c2887d52ecec0509365b6ded5b4c0ea07edac"
+source = "git+https://github.com/astewartau/QSM.rs.git?tag=v0.30.0#dd685ab07b73cec7160eef010a11253e1f4e35cb"
 dependencies = [
  "bytemuck",
  "delaunator",
@@ -889,7 +889,7 @@ dependencies = [
 [[package]]
 name = "qsmxt-config"
 version = "0.0.0"
-source = "git+https://github.com/QSMxT/QSMxT.git?tag=v9.14.0#d8729aedbb316780697b13e82a7611a271133bc9"
+source = "git+https://github.com/QSMxT/QSMxT.git?tag=v9.17.0#bce776a2af094baf5779b681ef29152ebbd206e2"
 dependencies = [
  "qsm-core",
  "serde",

--- a/rust-wasm/Cargo.toml
+++ b/rust-wasm/Cargo.toml
@@ -21,12 +21,12 @@ parallel = ["qsm-core/parallel", "dep:wasm-bindgen-rayon"]
 [dependencies]
 # Core QSM algorithms. `parallel` (rayon) is enabled via our own `parallel` feature for
 # threaded wasm builds; plain builds stay single-threaded.
-qsm-core = { git = "https://github.com/astewartau/QSM.rs.git", tag = "v0.28.0" }
+qsm-core = { git = "https://github.com/astewartau/QSM.rs.git", tag = "v0.30.0" }
 
 # Pipeline configuration, command generation, methods text.
 # qsmxt-config's canonical home is the QSMxT/QSMxT workspace (the old
 # astewartau/qsmxt.rs repo is being retired).
-qsmxt-config = { git = "https://github.com/QSMxT/QSMxT.git", tag = "v9.14.0" }
+qsmxt-config = { git = "https://github.com/QSMxT/QSMxT.git", tag = "v9.17.0" }
 
 # WASM bindings
 # getrandom (pulled by tract-onnx) needs the "js" backend on wasm32 (browser crypto).


### PR DESCRIPTION
Picks up [QSM.rs v0.30.0](https://github.com/astewartau/QSM.rs/releases/tag/v0.30.0) and [QSMxT v9.17.0](https://github.com/QSMxT/QSMxT/releases/tag/v9.17.0).

## Both pins have to move together

`qsmxt-config` declares its **own** `qsm-core` dependency, so bumping only the direct pin resolves **two copies** into the lockfile:

```
qsm_wasm ──► qsm-core v0.30.0          (direct)
         └─► qsmxt-config v9.14.0 ──► qsm-core v0.28.0
```

For a browser WASM target that means shipping the whole library twice, plus the risk of type mismatches wherever `qsmxt-config` exposes `qsm-core` types across the boundary. QSMxT v9.17.0 moved both of its own pins to v0.30.0, so pointing at that tag collapses it back to **a single copy** — confirmed in the lockfile.

## What comes with it

- **AMP-PE adaptive damping.** The solver could diverge outright on in-vivo local fields, with χ growing without bound to ~1e34. It now detects a diverging sweep, restores the last good state and damps harder, with the damping ceiling ratcheting down. Inert on data that does not diverge.
- **V-SHARP default threshold `0.05 → 0.2`.** More robust on the estimated fields real pipelines actually feed it; inert on a clean field. Changes V-SHARP output for callers relying on the default.
- **MEDI default λ tuned for radian-scale field** (from v0.29.0, which this repo had not yet taken — this is a two-version jump).

## Verification

Checked against `wasm32-unknown-unknown` in all three build configurations:

| config | result |
|---|---|
| default | ✅ |
| `onnx,simd` | ✅ |
| `onnx,simd,parallel` — the real threaded build, nightly with `-C target-feature=+atomics,+bulk-memory,+mutable-globals` and `-Z build-std` | ✅ |

The threaded one matters: a plain `cargo check --features parallel` fails on `wasm-bindgen-rayon` without those target features, so checking it the easy way would have been meaningless.

`wasm-pack` isn't available locally, so the full bundle build is left to CI on release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)